### PR TITLE
feat: render task list UI

### DIFF
--- a/personal-task-manager/src/App.css
+++ b/personal-task-manager/src/App.css
@@ -67,6 +67,17 @@
   margin: 0 0 0.4rem;
 }
 
+.taskListDescription {
+  margin: 0 0 0.5rem;
+  color: rgba(255, 255, 255, 0.74);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .taskListMeta {
   margin: 0;
   color: rgba(255, 255, 255, 0.72);
@@ -100,6 +111,12 @@
   background: rgba(88, 235, 156, 0.16);
   border: 1px solid rgba(88, 235, 156, 0.35);
   color: #63f3b0;
+}
+
+.taskListEmpty {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .taskDetailDescription {

--- a/personal-task-manager/src/components/TaskListItem.tsx
+++ b/personal-task-manager/src/components/TaskListItem.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom'
+import type { Task } from '../types/task'
+
+type TaskListItemProps = {
+  task: Task
+}
+
+/**
+ * Reusable renderer for a single task row in the list view. Keeping this logic
+ * isolated makes it trivial to reuse the same visual layout.
+ */
+export function TaskListItem({ task }: TaskListItemProps) {
+  const detailLink = `/tasks/${task.id}`
+
+  return (
+    <li className="taskListItem">
+      <div>
+        <p className="taskListTitle">{task.title}</p>
+        <p className="taskListDescription">{task.description}</p>
+        <p className="taskListMeta">
+          Status:{' '}
+          <span className={`badge badge--${task.status}`}>{task.status}</span>
+        </p>
+      </div>
+      <Link to={detailLink} className="taskListLink">
+        View details
+      </Link>
+    </li>
+  )
+}

--- a/personal-task-manager/src/routes/TaskListPage.tsx
+++ b/personal-task-manager/src/routes/TaskListPage.tsx
@@ -1,14 +1,30 @@
+import { TaskListItem } from '../components/TaskListItem'
+import { useTasks } from '../hooks/useTasks'
+
+/**
+ * List page consumes the shared task context and decides how the collection
+ * should be presented. Individual rows are delegated to `TaskListItem` so this
+ * component stays focused on data flow and empty-state decisions.
+ */
 export function TaskListPage() {
+  const { tasks } = useTasks()
+
   return (
     <section className="page">
       <header className="pageHeader">
         <h1>Tasks</h1>
       </header>
-      <p>
-        Task list UI will be implemented on branch <code>feature/task-list</code>.
-        For now this page acts as a placeholder so routing and context wiring can
-        be verified.
-      </p>
+      {tasks.length === 0 ? (
+        <p className="taskListEmpty">
+          You have no tasks yet. Add your first task to keep track of work.
+        </p>
+      ) : (
+        <ul className="taskList">
+          {tasks.map((task) => (
+            <TaskListItem key={task.id} task={task} />
+          ))}
+        </ul>
+      )}
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- render the task list using data from TaskProvider
- introduce a reusable TaskListItem component for each task row
- add empty-state messaging and supporting styles

## Testing
- pnpm lint
- pnpm build
- pnpm run dev (confirmed / shows mock tasks; manually cleared mock data using React dev tools to verify empty state)

Fixes #3
