### PR TITLE
feat: enable task editing and deletion

### DIFF
--- a/personal-task-manager/src/App.css
+++ b/personal-task-manager/src/App.css
@@ -144,9 +144,23 @@
   font-weight: 600;
 }
 
-.taskDetailNav a {
+.taskDetailNav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.taskDetailBackLink {
   color: #72d6ff;
   font-weight: 600;
+}
+
+.taskDetailActions {
+  display: flex;
+  gap: 0.75rem;
 }
 
 .taskForm {
@@ -226,5 +240,51 @@
 
 .primaryButton:focus-visible {
   outline: 3px solid rgba(128, 147, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.secondaryButton {
+  padding: 0.55rem 1.1rem;
+  border-radius: 12px;
+  background: rgba(114, 214, 255, 0.16);
+  border: 1px solid rgba(114, 214, 255, 0.4);
+  color: #9addff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 120ms ease, transform 120ms ease;
+}
+
+.secondaryButton:hover {
+  transform: translateY(-1px);
+  border-color: rgba(114, 214, 255, 0.65);
+}
+
+.secondaryButton:focus-visible {
+  outline: 3px solid rgba(114, 214, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.dangerButton {
+  padding: 0.55rem 1.1rem;
+  border-radius: 12px;
+  background: rgba(255, 82, 82, 0.2);
+  border: 1px solid rgba(255, 82, 82, 0.4);
+  color: #ff9b9b;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 120ms ease, transform 120ms ease;
+}
+
+.dangerButton:hover {
+  background: rgba(255, 82, 82, 0.32);
+  transform: translateY(-1px);
+}
+
+.dangerButton:focus-visible {
+  outline: 3px solid rgba(255, 82, 82, 0.45);
   outline-offset: 2px;
 }

--- a/personal-task-manager/src/App.tsx
+++ b/personal-task-manager/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom'
 import './App.css'
 import { TaskCreatePage } from './routes/TaskCreatePage'
 import { TaskDetailPage } from './routes/TaskDetailPage'
+import { TaskEditPage } from './routes/TaskEditPage'
 import { TaskListPage } from './routes/TaskListPage'
 
 function App() {
@@ -10,6 +11,7 @@ function App() {
       <Routes>
         <Route path="/" element={<TaskListPage />} />
         <Route path="/tasks/new" element={<TaskCreatePage />} />
+        <Route path="/tasks/:taskId/edit" element={<TaskEditPage />} />
         <Route path="/tasks/:taskId" element={<TaskDetailPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/personal-task-manager/src/routes/TaskDetailPage.tsx
+++ b/personal-task-manager/src/routes/TaskDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useTasks } from '../hooks/useTasks'
 
 /**
@@ -7,7 +7,8 @@ import { useTasks } from '../hooks/useTasks'
  */
 export function TaskDetailPage() {
   const { taskId } = useParams<{ taskId: string }>()
-  const { getTaskById } = useTasks()
+  const navigate = useNavigate()
+  const { deleteTask, getTaskById } = useTasks()
 
   if (!taskId) {
     return (
@@ -56,7 +57,32 @@ export function TaskDetailPage() {
         </div>
       </dl>
       <nav className="taskDetailNav">
-        <Link to="/">← Back to tasks</Link>
+        <Link to="/" className="taskDetailBackLink">
+          ← Back to tasks
+        </Link>
+        <div className="taskDetailActions">
+          <Link
+            to={`/tasks/${task.id}/edit`}
+            className="secondaryButton"
+            aria-label={`Edit task ${task.title}`}
+          >
+            Edit
+          </Link>
+          <button
+            type="button"
+            className="dangerButton"
+            onClick={() => {
+              const confirmed = window.confirm(
+                'Delete this task? This action cannot be undone.',
+              )
+              if (!confirmed) return
+              deleteTask(task.id)
+              navigate('/')
+            }}
+          >
+            Delete
+          </button>
+        </div>
       </nav>
     </section>
   )

--- a/personal-task-manager/src/routes/TaskEditPage.tsx
+++ b/personal-task-manager/src/routes/TaskEditPage.tsx
@@ -1,0 +1,63 @@
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { TaskForm } from '../components/TaskForm'
+import { useTasks } from '../hooks/useTasks'
+
+/**
+ * Allows editing an existing task. We prefill the shared TaskForm with the
+ * current values and push updates back through the TaskProvider.
+ */
+export function TaskEditPage() {
+  const { taskId } = useParams<{ taskId: string }>()
+  const navigate = useNavigate()
+  const { getTaskById, updateTask } = useTasks()
+
+  if (!taskId) {
+    return (
+      <section className="page">
+        <header className="pageHeader">
+          <h1>Task not found</h1>
+        </header>
+        <p>
+          Missing task identifier. <Link to="/">Return to your tasks.</Link>
+        </p>
+      </section>
+    )
+  }
+
+  const task = getTaskById(taskId)
+
+  if (!task) {
+    return (
+      <section className="page">
+        <header className="pageHeader">
+          <h1>Task not found</h1>
+        </header>
+        <p>
+          We could not locate a task with id <code>{taskId}</code>.{' '}
+          <Link to="/">Go back to the task list.</Link>
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="page">
+      <header className="pageHeader">
+        <h1>Edit task</h1>
+        <span className={`badge badge--${task.status}`}>{task.status}</span>
+      </header>
+      <TaskForm
+        initialValue={{
+          title: task.title,
+          description: task.description,
+          status: task.status,
+        }}
+        submitLabel="Update task"
+        onSubmit={(draft) => {
+          updateTask(task.id, draft)
+          navigate(`/tasks/${task.id}`)
+        }}
+      />
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add an edit route that reuses TaskForm with prefilled data
- expose edit/delete controls on the task detail page
- style secondary and destructive buttons for consistency

## Testing
- pnpm lint
- pnpm build
- pnpm run dev (edit a task and confirm detail updates; delete a task and confirm it disappears)

fix #9 
